### PR TITLE
New alternate asset object - v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+## [v1.1.0]
 
 ### Changed
-
-### Deprecated
+- No longer reference a STAC version
+- Alternate objects are not of type `Asset` but rather `AlternateAsset` which is just a restrictive version of an `Asset`
 
 ### Removed
-
-### Fixed
+- requirement for alternate (which meant it had to be used in all assets). There are no no required fields
 
 ## [v1.0.0]
 
 Initial release
 
-[Unreleased]: <https://github.com/stac-extensions/alternate-assets/compare/v1.0.0...HEAD>
+[Unreleased]: <https://github.com/stac-extensions/alternate-assets/compare/v1.1.0...HEAD>
+[v1.1.0]: <https://github.com/stac-extensions/alternate-assets/compare/v1.0.0...v1.1.0>
 [v1.0.0]: <https://github.com/stac-extensions/alternate-assets/tree/v1.0.0>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Alternate Assets Extension Specification
 
 - **Title:** Alternate Assets
-- **Identifier:** <https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json>
+- **Identifier:** <https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json>
 - **Field Name Prefix:** -
 - **Scope:** Asset
 - **Extension [Maturity Classification](https://github.com/radiantearth/stac-spec/tree/master/extensions/README.md#extension-maturity):** Proposal
@@ -22,14 +22,13 @@ to access it.
 
 | Field Name           | Type                      | Description |
 | -------------------- | ------------------------- | ----------- |
-| alternate         | Map<string, [Asset Object](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#asset-object)> | An array of alternate location information for an asset |
+| alternate         | Map<string, [AlternateAsset Object](#alternate-asset-object)> | An array of alternate location information for an asset |
 
-The alternate Assets are like any other Asset object, except should only contain fields relevant to the location and access of the asset. 
-In the simplest case, the object consists of a single field, `href`, but could include other fields if they do not specify
-attributes in the physical asset. For example, `gsd` represents the resolution of the data asset. Changing that would imply
-a different asset. Fields like `title` or `description` can be used to provide info on the alternate asset.
-Considering other extensions, the fields from the [Storage Extension](https://github.com/stac-extensions/storage) 
-could be used in an alternative asset to provide additional details on it's location.
+The Alternate Assets are similar to the core Asset object, except only contain fields relevant to the location and access of the asset. 
+In the simplest case, the object consists of a single field, `href`, but could include a title or description to provide additional info
+regarding the alternate location or URL. 
+The fields from the [Storage Extension](https://github.com/stac-extensions/storage) could be used in an AlternateAsset to 
+provide additional details on it's location.
 
 The key to each alternate asset, e.g.,
 
@@ -46,6 +45,14 @@ in an Item are all available via s3 direct access, the key for all of them shoul
 
 It is also recommended that the [item assets](https://github.com/stac-extensions/item-assets)
 extension be used in Collections to convey to users what the options are for alternate access.
+
+### Alternate Asset Object
+
+| Field Name  | Type      | Description |
+| ----------- | --------- | ----------- |
+| href        | string    | **REQUIRED.** URI to the asset object. Relative and absolute URI are both allowed. |
+| title       | string    | The displayed title for clients and users. |
+| description | string    | A description of the Asset providing additional details, such as how it was processed or created. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 
 ## Contributing
 

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -2,7 +2,7 @@
   "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json"
   ],
   "type": "Collection",
   "id": "collection-1",

--- a/examples/item.json
+++ b/examples/item.json
@@ -50,6 +50,9 @@
   "assets": {
     "data": {
       "href": "https://mycoolsat.com/examples/file.xyz",
+      "roles": [
+        "data"
+      ],
       "alternate": {
         "s3": {
           "title": "s3 Access",

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,7 +1,7 @@
 {
   "stac_version": "1.0.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json"
   ],
   "type": "Feature",
   "id": "item",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -16,12 +16,12 @@
           "properties": {
             "type": {
               "const": "Feature"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/asset"
-              }
+            }
+          },
+          "assets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/assets"
             }
           }
         },
@@ -41,18 +41,18 @@
           "properties": {
             "type": {
               "const": "Collection"
-            },
-            "assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/asset"
-              }
-            },
-            "item_assets": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/item_asset"
-              }
+            }
+          },
+          "assets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/assets"
+            }
+          },
+          "item_assets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/assets"
             }
           }
         },
@@ -81,29 +81,45 @@
       "title": "Assets",
       "description": "Links to assets",
       "type": "object",
-      "additionalProperties": {
-        "$ref": "#/definitions/asset"
-      }
-    },
-    "asset": {
-      "type": "object",
-      "required": [
-        "alternate"
-      ],
       "properties": {
         "alternate": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#/definitions/asset"
+            "$ref": "#/definitions/asset"
           }
         }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/asset" 
       }
     },
-    "item_asset": {
+    "asset": {
       "type": "object",
       "properties": {
-        "alternate": {
-          "type": "object"
+        "href": {
+          "title": "Asset reference",
+          "type": "string",
+          "format": "iri-reference",
+          "minLength": 1
+        },
+        "title": {
+          "title": "Asset title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Asset description",
+          "type": "string"
+        },
+        "type": {
+          "title": "Asset type",
+          "type": "string"
+        },
+        "roles": {
+          "title": "Asset roles",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json#",
+  "$id": "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json#",
   "title": "Alternate Assets Extension",
   "description": "STAC Alternate Assets Extension for STAC Items and STAC Collections.",
   "oneOf": [
@@ -16,12 +16,12 @@
           "properties": {
             "type": {
               "const": "Feature"
-            }
-          },
-          "assets": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/assets"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/alternate_assets"
+              }
             }
           }
         },
@@ -41,18 +41,18 @@
           "properties": {
             "type": {
               "const": "Collection"
-            }
-          },
-          "assets": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/assets"
-            }
-          },
-          "item_assets": {
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/assets"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/alternate_assets"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/alternate_item_assets"
+              }
             }
           }
         },
@@ -72,12 +72,12 @@
         "stac_extensions": {
           "type": "array",
           "contains": {
-            "const": "https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json"
+            "const": "https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json"
           }
         }
       }
     },
-    "assets": {
+    "alternate_assets": {
       "title": "Assets",
       "description": "Links to assets",
       "type": "object",
@@ -85,40 +85,45 @@
         "alternate": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/asset"
+            "required": ["href"],
+            "properties": {
+              "href": {
+                "title": "Asset reference",
+                "type": "string",
+                "format": "iri-reference",
+                "minLength": 1
+              },
+              "title": {
+                "title": "Asset title",
+                "type": "string"
+              },
+              "description": {
+                "title": "Asset description",
+                "type": "string"
+              }
+            }
           }
         }
-      },
-      "additionalProperties": {
-        "$ref": "#/definitions/asset" 
       }
     },
-    "asset": {
+    "alternate_item_assets": {
+      "title": "Assets",
+      "description": "Links to assets",
       "type": "object",
       "properties": {
-        "href": {
-          "title": "Asset reference",
-          "type": "string",
-          "format": "iri-reference",
-          "minLength": 1
-        },
-        "title": {
-          "title": "Asset title",
-          "type": "string"
-        },
-        "description": {
-          "title": "Asset description",
-          "type": "string"
-        },
-        "type": {
-          "title": "Asset type",
-          "type": "string"
-        },
-        "roles": {
-          "title": "Asset roles",
-          "type": "array",
-          "items": {
-            "type": "string"
+        "alternate": {
+          "type": "object",
+          "additionalProperties": {
+            "properties": {
+              "title": {
+                "title": "Asset title",
+                "type": "string"
+              },
+              "description": {
+                "title": "Asset description",
+                "type": "string"
+              }            
+            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
     "check-markdown": "remark . -f -r .github/remark.yaml",
-    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json=./json-schema/schema.json",
-    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/alternate-assets/v1.0.0/schema.json=./json-schema/schema.json"
+    "check-examples": "stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json=./json-schema/schema.json",
+    "format-examples": "stac-node-validator . --format --schemaMap https://stac-extensions.github.io/alternate-assets/v1.1.0/schema.json=./json-schema/schema.json"
   },
   "dependencies": {
     "remark-cli": "^8.0.0",


### PR DESCRIPTION
Changes for a v1.1.0

New alternate asset object instead of asset.  Just contains `href`, `title`, `description`.